### PR TITLE
Fix a couple of End Of World issues

### DIFF
--- a/src/utopiaengine/Game.java
+++ b/src/utopiaengine/Game.java
@@ -141,10 +141,10 @@ public class Game implements ActionListener {
     private static void doSearch() {
         player.getLocation().incrementSearchCounter();
         
-        if (gameOver) {
+        if (timeTrack.outOfTime()) {
             return;
         }
-        
+                
         SearchDialog d = new SearchDialog(player.getLocation());
         Optional<Integer> result = d.showAndWait();
 

--- a/src/utopiaengine/TimeTrack.java
+++ b/src/utopiaengine/TimeTrack.java
@@ -64,9 +64,10 @@ public class TimeTrack {
     }
     
     public void tick() {
-        if (currentTime < 22) {
-            ++currentTime;
+        if (outOfTime) {
+            return;
         }
+        ++currentTime;
         
         /* Has the world ended? */
         if ((currentTime - daysExtended) >= 15) {


### PR DESCRIPTION
- Don't post more than one End Of World message
- Fixed a race condition that was causing the Search dialog to appear even if searching caused the time to tick, which in turn 
  caused the game to end.
